### PR TITLE
feat: SSR/SSG terminal pages with static output pattern

### DIFF
--- a/src/__tests__/components/TerminalEmulator.test.tsx
+++ b/src/__tests__/components/TerminalEmulator.test.tsx
@@ -18,6 +18,7 @@ vi.mock('@/stores/terminal-store', () => ({
   $terminalPromptRef: {
     set: vi.fn(),
   },
+  initializeTerminal: vi.fn(),
 }));
 
 vi.mock('next-intl', () => ({
@@ -46,12 +47,14 @@ import {
   $terminalHistory,
   $terminalHistoryVisibleIdx,
   $terminalPromptRef,
+  initializeTerminal,
 } from '@/stores/terminal-store';
 
 describe('TerminalEmulator', () => {
   const mockHistoryGet = vi.mocked($terminalHistory.get);
   const mockHistoryVisibleIdxGet = vi.mocked($terminalHistoryVisibleIdx.get);
   const mockPromptRefSet = vi.mocked($terminalPromptRef.set);
+  const _mockInitializeTerminal = vi.mocked(initializeTerminal);
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -1,10 +1,25 @@
 import Contact from '@/components/contact/Contact';
+import StaticOutput from '@/components/StaticOutput';
+import TerminalEmulator from '@/components/terminal/TerminalEmulator';
 import type { RouteData } from '@/types/routing';
+import { Command } from '@/types/terminal';
 import { setPageMeta } from '@/utils/metadata-utils';
+
+interface ContactPageProps {
+  params: Promise<{ locale: string }>;
+}
 
 export const generateMetadata = async (routeData: RouteData) =>
   await setPageMeta(routeData, 'contact');
 
-export default function ContactPage() {
-  return <Contact />;
+export default async function ContactPage({ params }: ContactPageProps) {
+  await params;
+  return (
+    <>
+      <StaticOutput>
+        <Contact />
+      </StaticOutput>
+      <TerminalEmulator initialCommand={Command.Contact} />
+    </>
+  );
 }

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,6 +1,34 @@
-'use client';
+import { getTranslations } from 'next-intl/server';
+import StaticOutput from '@/components/StaticOutput';
 import TerminalEmulator from '@/components/terminal/TerminalEmulator';
+import { Command } from '@/types/terminal';
 
-export default function HomePage() {
-  return <TerminalEmulator />;
+interface HomePageProps {
+  params: Promise<{ locale: string }>;
+}
+
+export default async function HomePage({ params }: HomePageProps) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'Terminal' });
+
+  return (
+    <>
+      <StaticOutput>
+        <div>
+          <p>
+            {t.rich('cmds.welcome.welcome', {
+              name: (name) => name,
+            })}
+          </p>
+          <p>{t('cmds.welcome.site_intro_1')}</p>
+          <p>
+            {t.rich('cmds.welcome.site_intro_2', {
+              cmd: () => 'help',
+            })}
+          </p>
+        </div>
+      </StaticOutput>
+      <TerminalEmulator initialCommand={Command.Welcome} />
+    </>
+  );
 }

--- a/src/app/[locale]/services/page.tsx
+++ b/src/app/[locale]/services/page.tsx
@@ -1,0 +1,30 @@
+import { getTranslations } from 'next-intl/server';
+import StaticOutput from '@/components/StaticOutput';
+import TerminalEmulator from '@/components/terminal/TerminalEmulator';
+import type { RouteData } from '@/types/routing';
+import { Command } from '@/types/terminal';
+import { setPageMeta } from '@/utils/metadata-utils';
+
+interface ServicesPageProps {
+  params: Promise<{ locale: string }>;
+}
+
+export const generateMetadata = async (routeData: RouteData) =>
+  await setPageMeta(routeData, 'services');
+
+export default async function ServicesPage({ params }: ServicesPageProps) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'Terminal' });
+
+  return (
+    <>
+      <StaticOutput>
+        <div>
+          <p>{t('cmds.services.title')}</p>
+          <p>{t('cmds.services.description')}</p>
+        </div>
+      </StaticOutput>
+      <TerminalEmulator initialCommand={Command.Services} />
+    </>
+  );
+}

--- a/src/app/[locale]/whoami/page.tsx
+++ b/src/app/[locale]/whoami/page.tsx
@@ -1,10 +1,25 @@
 import AboutMe from '@/components/about-me/AboutMe';
+import StaticOutput from '@/components/StaticOutput';
+import TerminalEmulator from '@/components/terminal/TerminalEmulator';
 import type { RouteData } from '@/types/routing';
+import { Command } from '@/types/terminal';
 import { setPageMeta } from '@/utils/metadata-utils';
+
+interface WhoamiPageProps {
+  params: Promise<{ locale: string }>;
+}
 
 export const generateMetadata = async (routeData: RouteData) =>
   await setPageMeta(routeData, 'whoami');
 
-export default function WhoamiPage() {
-  return <AboutMe />;
+export default async function WhoamiPage({ params }: WhoamiPageProps) {
+  await params;
+  return (
+    <>
+      <StaticOutput>
+        <AboutMe />
+      </StaticOutput>
+      <TerminalEmulator initialCommand={Command.Whoami} />
+    </>
+  );
 }

--- a/src/components/StaticOutput.tsx
+++ b/src/components/StaticOutput.tsx
@@ -1,0 +1,11 @@
+interface StaticOutputProps {
+  children: React.ReactNode;
+}
+
+export default function StaticOutput({ children }: StaticOutputProps) {
+  return (
+    <div aria-hidden="true" className="sr-only">
+      {children}
+    </div>
+  );
+}

--- a/src/components/cmd-outputs/ServicesOutput.tsx
+++ b/src/components/cmd-outputs/ServicesOutput.tsx
@@ -76,10 +76,7 @@ function ServiceCard({ statusMsg, t, dayjs }: ServiceCardProps) {
           </Typography>
 
           <div className="flex items-center justify-end gap-(--lsd-spacing-smaller) mt-(--lsd-spacing-large)">
-            <RecordIcon
-              weight="duotone"
-              className="animate-pulse text-(--lsd-text-destructive)"
-            />
+            <RecordIcon weight="duotone" className="animate-pulse" />
             <Typography variant="body3">
               {t('cmds.services.lastChecked')}{' '}
               {dayjs(statusMsg.timestamp).fromNow()}
@@ -123,7 +120,7 @@ export default function ServicesOutput({ t }: CommandOutputProps) {
 
   return (
     <div className="py-(--lsd-spacing-small)">
-      <Typography variant="body1">{t('cmds.services.title')}</Typography>
+      <Typography variant="body2">{t('cmds.services.title')}</Typography>
 
       {isWaitingForHeartbeats ? (
         <div className="flex items-center gap-(--lsd-spacing-small) mt-(--lsd-spacing-small)">

--- a/src/components/terminal/TerminalEmulator.tsx
+++ b/src/components/terminal/TerminalEmulator.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useStore } from '@nanostores/react';
 import { useTranslations } from 'next-intl';
 import { useEffect, useRef, useState } from 'react';
@@ -5,11 +7,18 @@ import {
   $terminalHistory,
   $terminalHistoryVisibleIdx,
   $terminalPromptRef,
+  initializeTerminal,
 } from '@/stores/terminal-store';
 import UnknownCmdOutput from '../cmd-outputs/UnknownCmdOutput';
 import TerminalPrompt, { type TerminalPromptRef } from './TerminalPrompt';
 
-export default function TerminalEmulator() {
+interface TerminalEmulatorProps {
+  initialCommand?: string;
+}
+
+export default function TerminalEmulator({
+  initialCommand = 'welcome',
+}: TerminalEmulatorProps) {
   const history = useStore($terminalHistory);
   const historyVisibleIdx = useStore($terminalHistoryVisibleIdx);
 
@@ -32,6 +41,12 @@ export default function TerminalEmulator() {
       }, 100);
     }
   }, [hasWindow]);
+
+  useEffect(() => {
+    if (hasWindow) {
+      initializeTerminal(initialCommand);
+    }
+  }, [hasWindow, initialCommand]);
 
   return (
     hasWindow && (

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -1,5 +1,6 @@
 export const Routes = {
-  terminal: '/',
+  welcome: '/',
   whoami: '/whoami',
+  services: '/services',
   contact: '/contact',
 };

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -66,7 +66,7 @@
       },
       "services": {
         "description": "Display my self-hosted services status",
-        "title": "Services that I proudly self-host:",
+        "title": "Services that I proudly self-host",
         "connectionStatus": "Connection Status",
         "loading": "(Loading...)",
         "waitingForHeartbeats": "Waiting for heartbeats...",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -13,8 +13,9 @@
     "ctrlc": "CTRL+C"
   },
   "Pages": {
-    "terminal": "home",
+    "welcome": "welcome",
     "whoami": "whoami",
+    "services": "services",
     "contact": "contact"
   },
   "Status": {

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -66,7 +66,7 @@
       },
       "services": {
         "description": "Afficher l'état de mes services auto-hébergés",
-        "title": "Services que j'héberge avec fierté :",
+        "title": "Services que j'héberge avec fierté",
         "connectionStatus": "État de la connexion",
         "loading": "(Chargement...)",
         "waitingForHeartbeats": "En attente de heartbeats...",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -13,8 +13,9 @@
     "ctrlc": "CTRL+C"
   },
   "Pages": {
-    "terminal": "accueil",
-    "whoami": "qui_suis_je",
+    "welcome": "bienvenue",
+    "whoami": "qui suis-je",
+    "services": "services",
     "contact": "contact"
   },
   "Status": {

--- a/src/stores/terminal-store.ts
+++ b/src/stores/terminal-store.ts
@@ -1,9 +1,9 @@
-import { atom, effect, onMount } from 'nanostores';
+import { atom, effect } from 'nanostores';
 import type { KeyboardEvent, RefObject } from 'react';
 import type { TerminalPromptRef } from '@/components/terminal/TerminalPrompt';
 import { Commands } from '@/constants/commands';
 import { Key } from '@/types/keyboard';
-import { Command, type CommandEntry } from '@/types/terminal';
+import type { CommandEntry } from '@/types/terminal';
 import { getPastInputStr, parseTerminalEntry } from '@/utils/terminal-utils';
 
 export const $terminalInput = atom('');
@@ -16,15 +16,6 @@ export const $terminalKeyEvent = atom<KeyboardEvent | null>(null);
 export const $terminalPromptRef =
   atom<RefObject<TerminalPromptRef | null> | null>(null);
 export const $scrollY = atom(0);
-
-const $hasGreeted = atom(false);
-
-onMount($terminalInput, () => {
-  if (!$hasGreeted.get()) {
-    $hasGreeted.set(true);
-    simulateInput(Command.Welcome);
-  }
-});
 
 effect($terminalKeyEvent, (event) => {
   const isReadOnly = $terminalInputReadOnly.get();
@@ -98,6 +89,13 @@ export function simulateInput(input: string) {
 
   $terminalInput.set('');
   addChar(input);
+}
+
+export function initializeTerminal(command: string) {
+  $terminalHistory.set([]);
+  $terminalHistoryIdx.set(-1);
+  $terminalHistoryVisibleIdx.set(0);
+  simulateInput(command);
 }
 
 export function setPreviousHistoryEntry() {


### PR DESCRIPTION
## Summary

Converts terminal-based pages to server-side rendered (SSG) architecture with a new static output pattern for improved SEO and accessibility.

## Changes

- **New StaticOutput component**: Wraps static content with `sr-only` + `aria-hidden` for screen reader accessibility
- **Terminal emulator refactoring**: Added `initialCommand` prop and `initializeTerminal()` for page-specific command execution
- **Page architecture**: All pages now async with `<StaticOutput>` wrapping static content + `<TerminalEmulator>` for interactivity
- **New services page**: Added `/services` route following the same SSR pattern
- **Route naming**: Renamed `terminal` → `welcome` for clarity
- **i18n updates**: Added translations for new page, fixed services title punctuation